### PR TITLE
Update 2019-10-19-clang-clause.markdown

### DIFF
--- a/_posts/2019-10-19-clang-clause.markdown
+++ b/_posts/2019-10-19-clang-clause.markdown
@@ -444,6 +444,7 @@ Now you have a new test file `alloc2.c` which uses the `allocate` directive. The
 ```
 int main()
 {
+    int *A;
 #pragma omp allocate(A)
     return 0;
 }


### PR DESCRIPTION
The current version doesn't match https://raw.githubusercontent.com/chunhualiao/freecc-examples/master/allocate/alloc2.c